### PR TITLE
Fix allow modal to be open by default

### DIFF
--- a/controllers/dialog_controller.js
+++ b/controllers/dialog_controller.js
@@ -10,6 +10,12 @@ export default class extends Controller {
     },
   }
 
+  connect() {
+    if (this.openValue) {
+      this.open()
+    }
+  }
+
   open(e) {
     e.preventDefault()
     document.body.insertAdjacentHTML('beforeend', this.contentTarget.innerHTML)


### PR DESCRIPTION
This doesn't seem to be enough for the dialog/modal to be open by default when needed

`= render PhlexUI::Dialog.new(open: true) do`


[Linked issue](https://github.com/PhlexUI/phlex_ui_stimulus/issues/7)
[Linked issue 2](https://github.com/PhlexUI/phlex_ui_stimulus/issues/9)