### PR TITLE
Prevent body scroll while alert dialog is open

### DIFF
--- a/controllers/alert_dialog_controller.js
+++ b/controllers/alert_dialog_controller.js
@@ -18,5 +18,7 @@ export default class extends Controller {
 
   open() {
     document.body.insertAdjacentHTML("beforeend", this.contentTarget.innerHTML);
+    // prevent scroll on body
+    document.body.classList.add("overflow-hidden");
   }
 }


### PR DESCRIPTION
Applying "overflow-hidden" class to the document's body to prevent scroll while alert dialog is open.

This is already done in the dialog controller, but was not in the alert dialog controller.